### PR TITLE
feat: API를 두 개의 endpoint로 분리 및 수정

### DIFF
--- a/src/main/java/com/planu/group_meeting/controller/GroupController.java
+++ b/src/main/java/com/planu/group_meeting/controller/GroupController.java
@@ -1,9 +1,7 @@
 package com.planu.group_meeting.controller;
 
-import com.fasterxml.jackson.databind.ser.Serializers;
 import com.planu.group_meeting.config.auth.CustomUserDetails;
 import com.planu.group_meeting.dto.BaseResponse;
-import com.planu.group_meeting.dto.GroupDTO.GroupDetailResponse;
 import com.planu.group_meeting.dto.GroupInviteResponseDTO;
 import com.planu.group_meeting.dto.GroupResponseDTO;
 import com.planu.group_meeting.service.GroupScheduleService;
@@ -16,10 +14,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
@@ -76,21 +73,5 @@ public class GroupController {
         groupService.leaveGroup(userDetails.getId(), groupId);
 
         return BaseResponse.toResponseEntity(HttpStatus.OK, "그룹 탈퇴 성공");
-    }
-
-
-    @GetMapping("/{groupId}/detail")
-    public ResponseEntity<GroupDetailResponse> groupDetail(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                           @PathVariable("groupId") Long groupId) {
-        LocalDateTime today = LocalDateTime.now();
-        System.out.println(groupService.findNameByGroupId(groupId));
-        System.out.println(groupScheduleService.findTodaySchedulesByToday(groupId, today));
-        System.out.println(groupScheduleService.findScheduleOverViewByToday(groupId, today));
-
-        return ResponseEntity.ok(new GroupDetailResponse(
-                groupService.findNameByGroupId(groupId),
-                groupScheduleService.findTodaySchedulesByToday(groupId, today),
-                groupScheduleService.findScheduleOverViewByToday(groupId, today)
-        ));
     }
 }

--- a/src/main/java/com/planu/group_meeting/controller/GroupScheduleController.java
+++ b/src/main/java/com/planu/group_meeting/controller/GroupScheduleController.java
@@ -2,20 +2,27 @@ package com.planu.group_meeting.controller;
 
 import com.planu.group_meeting.config.auth.CustomUserDetails;
 import com.planu.group_meeting.dto.BaseResponse;
+import com.planu.group_meeting.dto.GroupScheduleDTO;
 import com.planu.group_meeting.dto.GroupScheduleDTO.GroupScheduleRequest;
 import com.planu.group_meeting.service.GroupScheduleService;
+import com.planu.group_meeting.service.GroupService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/groups")
 @RequiredArgsConstructor
 public class GroupScheduleController {
 
+    private final GroupService groupService;
     private final GroupScheduleService groupScheduleService;
 
     @PostMapping("{groupId}/schedules")
@@ -24,6 +31,27 @@ public class GroupScheduleController {
                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
         groupScheduleService.insert(groupId, groupScheduleRequest);
         return BaseResponse.toResponseEntity(HttpStatus.CREATED, "그룹 일정 생성 성공");
+    }
+
+    @GetMapping("/{groupId}/today")
+    public ResponseEntity<GroupScheduleDTO.GroupTodayScheduleResponse> groupTodaySchedule(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                          @PathVariable("groupId") Long groupId) {
+        LocalDateTime today = LocalDateTime.now();
+        return ResponseEntity.ok(new GroupScheduleDTO.GroupTodayScheduleResponse(
+                groupService.findNameByGroupId(groupId),
+                groupScheduleService.findTodaySchedulesByToday(groupId, today)
+        ));
+    }
+
+    @GetMapping("/{groupId}/calendar")
+    public ResponseEntity<GroupScheduleDTO.groupOverViewsResponse> groupRequestSchedule(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("groupId") Long groupId,
+            @RequestParam(required = false) @DateTimeFormat(pattern="yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern="yyyy-MM-dd") LocalDate endDate
+     )
+    {
+        return ResponseEntity.ok(new GroupScheduleDTO.groupOverViewsResponse(groupScheduleService.findScheduleOverViewByToday(groupId, startDate, endDate)));
     }
 }
 

--- a/src/main/java/com/planu/group_meeting/dao/GroupScheduleDAO.java
+++ b/src/main/java/com/planu/group_meeting/dao/GroupScheduleDAO.java
@@ -13,11 +13,10 @@ import java.util.List;
 public interface GroupScheduleDAO {
 
     List<todayScheduleResponse> findTodaySchedulesByToday(Long groupId, LocalDateTime today);
-    List<scheduleOverViewResponse> findScheduleOverViewsByToday(Long groupId, LocalDateTime today);
+
+    List<scheduleOverViewResponse> findScheduleOverViewsByRange(Long groupId, LocalDate startDate, LocalDate endDate);
 
     boolean existsScheduleByDate(Long userId, LocalDate date);
 
     void insert(GroupSchedule groupSchedule);
-
-    Long findIdByEntity(GroupSchedule groupSchedule);
 }

--- a/src/main/java/com/planu/group_meeting/dao/GroupUserDAO.java
+++ b/src/main/java/com/planu/group_meeting/dao/GroupUserDAO.java
@@ -1,0 +1,10 @@
+package com.planu.group_meeting.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface GroupUserDAO {
+    Boolean isGroupMember(Long userId, Long groupId);
+
+    Boolean isLeader(Long userId, Long groupId);
+}

--- a/src/main/java/com/planu/group_meeting/dto/GroupDTO.java
+++ b/src/main/java/com/planu/group_meeting/dto/GroupDTO.java
@@ -1,6 +1,5 @@
 package com.planu.group_meeting.dto;
 
-import com.planu.group_meeting.dto.GroupScheduleDTO.scheduleOverViewResponse;
 import com.planu.group_meeting.dto.GroupScheduleDTO.todayScheduleResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,12 +8,5 @@ import java.util.List;
 
 public class GroupDTO {
 
-    @Getter
-    @AllArgsConstructor
-    public static class GroupDetailResponse {
-        private String GroupName;
-        private List<todayScheduleResponse> todaySchedules;
-        private List<scheduleOverViewResponse> groupSchedules;
-    }
 
 }

--- a/src/main/java/com/planu/group_meeting/dto/GroupScheduleDTO.java
+++ b/src/main/java/com/planu/group_meeting/dto/GroupScheduleDTO.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 
@@ -59,7 +60,7 @@ public class GroupScheduleDTO {
     public static class todayScheduleResponse {
         private Long id;
         private String title;
-        private LocalDateTime startDateTime;
+        private String startDateTime;
         private String location;
     }
 
@@ -70,5 +71,18 @@ public class GroupScheduleDTO {
         private LocalDateTime startDateTime;
         private LocalDateTime endDateTime;
         private String color;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class GroupTodayScheduleResponse {
+        private String GroupName;
+        private List<todayScheduleResponse> todaySchedules;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class groupOverViewsResponse {
+        private List<scheduleOverViewResponse> groupSchedules;
     }
 }

--- a/src/main/java/com/planu/group_meeting/service/GroupScheduleService.java
+++ b/src/main/java/com/planu/group_meeting/service/GroupScheduleService.java
@@ -15,7 +15,9 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 @Service
@@ -32,8 +34,13 @@ public class GroupScheduleService {
     }
 
     @Transactional
-    public List<scheduleOverViewResponse> findScheduleOverViewByToday(Long groupId, LocalDateTime today) {
-        return groupScheduleDAO.findScheduleOverViewsByToday(groupId, today);
+    public List<scheduleOverViewResponse> findScheduleOverViewByToday(Long groupId, LocalDate startDate, LocalDate endDate) {
+        LocalDateTime today = LocalDateTime.now();
+        if(startDate == null || endDate == null) {
+            startDate = today.toLocalDate().with(TemporalAdjusters.firstDayOfMonth());
+            endDate = today.toLocalDate().with(TemporalAdjusters.lastDayOfMonth());
+        }
+        return groupScheduleDAO.findScheduleOverViewsByRange(groupId, startDate, endDate);
     }
 
     @Transactional
@@ -60,8 +67,6 @@ public class GroupScheduleService {
             List<GroupScheduleUnregisteredParticipant> unregisteredParticipants = unregisteredParticipantNames.stream()
                     .map(userName -> new GroupScheduleUnregisteredParticipant(groupSchedule.getId(), userName))
                     .toList();
-
-            System.out.println("디버그: " + unregisteredParticipants);
             groupScheduleUnregisteredParticipantDAO.insert(unregisteredParticipants);
         }
     }

--- a/src/main/java/com/planu/group_meeting/service/GroupService.java
+++ b/src/main/java/com/planu/group_meeting/service/GroupService.java
@@ -2,6 +2,7 @@ package com.planu.group_meeting.service;
 
 import com.planu.group_meeting.config.auth.CustomUserDetails;
 import com.planu.group_meeting.dao.GroupDAO;
+import com.planu.group_meeting.dao.GroupUserDAO;
 import com.planu.group_meeting.dao.UserDAO;
 import com.planu.group_meeting.dto.GroupInviteResponseDTO;
 import com.planu.group_meeting.dto.GroupResponseDTO;
@@ -22,12 +23,14 @@ public class GroupService {
     private final GroupDAO groupDAO;
     private final UserDAO userDAO;
     private final S3Uploader s3Uploader;
+    private final GroupUserDAO groupUserDAO;
 
     @Autowired
-    public GroupService(GroupDAO groupDAO, UserDAO userDAO, S3Uploader s3Uploader) {
+    public GroupService(GroupDAO groupDAO, UserDAO userDAO, S3Uploader s3Uploader, GroupUserDAO groupUserDAO) {
         this.groupDAO = groupDAO;
         this.userDAO = userDAO;
         this.s3Uploader = s3Uploader;
+        this.groupUserDAO = groupUserDAO;
     }
 
     @Transactional
@@ -139,5 +142,10 @@ public class GroupService {
     @Transactional
     public String findNameByGroupId(Long groupId) {
         return groupDAO.findNameByGroupId(groupId);
+    }
+
+    @Transactional
+    public Boolean isGroupMember(Long userId, Long groupId) {
+        return groupUserDAO.isGroupMember(userId, groupId);
     }
 }

--- a/src/main/resources/mapper/GroupScheduleMapper.xml
+++ b/src/main/resources/mapper/GroupScheduleMapper.xml
@@ -6,18 +6,17 @@
 <mapper namespace="com.planu.group_meeting.dao.GroupScheduleDAO">
     <select id="findTodaySchedulesByToday"
             resultType="com.planu.group_meeting.dto.GroupScheduleDTO$todayScheduleResponse">
-        SELECT id, title, start_datetime as startDateTime, location
+        SELECT id, title, date_format(start_datetime, '%p %h시') as startDateTime, location
         FROM GROUP_SCHEDULE
-        WHERE group_id = #{groupId}
-          and date (start_datetime) = #{today}
+        WHERE group_id = #{groupId} and date (start_datetime) = date(#{today})
     </select>
 
-    <select id="findScheduleOverViewsByToday"
+    <select id="findScheduleOverViewsByRange"
             resultType="com.planu.group_meeting.dto.GroupScheduleDTO$scheduleOverViewResponse">
         SELECT id, title, start_datetime as startDateTIme, end_datetime as endDateTime, color
         FROM GROUP_SCHEDULE
-        WHERE group_id = #{groupId} and year (start_datetime) = year (#{today})
-          and month (start_datetime) = month (#{today})
+        WHERE group_id = #{groupId} and start_datetime >= #{startDate} and #{endDate} >= start_datetime
+        ORDER BY date(start_datetime) ASC, datediff(end_datetime, start_datetime) desc;
     </select>
 
     <select id="existsScheduleByDate" resultType="boolean">

--- a/src/main/resources/mapper/GroupUserMapper.xml
+++ b/src/main/resources/mapper/GroupUserMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.planu.group_meeting.dao.GroupUserDAO">
+
+    <select id="isGroupMember" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1
+            FROM GROUP_USER
+            WHERE group_id = #{groupId} and user_id = #{user_id}
+        );
+    </select>
+
+    <select id="isLeader" resultType="boolean">
+        SELECT CASE
+            WHEN GROUP_ROLE = 'LEADER' THEN TRUE
+            ELSE FALSE
+        END AS isLeader
+        FROM GROUP_USER
+        WHERE group_id = #{groupId} and user_id = #{userId};
+    </select>
+</mapper>


### PR DESCRIPTION
그룹 상세 페이지에 필요한 정보를 제공하는 API를 두 개로 분리하였음.
이 과정에서 프론트가 요청한 수정 사항들을 모두 적용하였음

## #101 

> ex) #이슈번호

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 그룹 상세 페이지에서 정보 제공 API를 두 개로 분리
> 오늘 일정 정보에서 시작 날짜 정보 'AM 7시', 'PM 5시' 등으로 수정
> 요청한 범위 내 일정들을 시작 날짜가 빠른 순, 같다면 (종료 날짜) - (시작 날짜)가 큰 순서대로 정렬하여 제공
> 이후 사용하게 될 로그인한 회원이 그룹원인지, 리더인지 판별하는 API를 미리 생성( 그룹 일정에서 사용할 예정)

## 📝수정 내용(선택)
> -

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
