### PR TITLE
fix: 그룹 초대 요청 수락 API 수정

### DIFF
--- a/src/main/java/com/planu/group_meeting/dao/GroupDAO.java
+++ b/src/main/java/com/planu/group_meeting/dao/GroupDAO.java
@@ -22,7 +22,7 @@ public interface GroupDAO {
 
     int deleteGroupUserByUserIdAndGroupId(Long userId, Long groupId);
 
-    void UpdateGroupUserGroupStatus(Long userId, Long groupId);
+    void updateGroupUserGroupStatus(Long userId, Long groupId);
 
     String findNameByGroupId(Long groupId);
 

--- a/src/main/java/com/planu/group_meeting/service/GroupService.java
+++ b/src/main/java/com/planu/group_meeting/service/GroupService.java
@@ -107,7 +107,7 @@ public class GroupService {
             throw new IllegalArgumentException("이미 그룹에 속해 있습니다.");
         }
 
-        groupDAO.UpdateGroupUserGroupStatus(customUserDetails.getId(), groupId);
+        groupDAO.updateGroupUserGroupStatus(customUserDetails.getId(), groupId);
 
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #136 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 함수명 오타로 인한 API 호출 오류 수정

## 📝수정 내용(선택)
> 서비스단과 DAO의 UpdateGroupUserGroupStatus 함수명을 updateGroupUserGroupStatus로 수정

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
