### PR TITLE
fix: 그룹 오늘 일정 조회 API 수정

### DIFF
--- a/src/main/java/com/planu/group_meeting/dto/GroupScheduleDTO.java
+++ b/src/main/java/com/planu/group_meeting/dto/GroupScheduleDTO.java
@@ -55,6 +55,7 @@ public class GroupScheduleDTO {
     }
 
     @Getter
+    @Setter
     public static class todayScheduleResponse {
         private Long id;
         private String title;

--- a/src/main/java/com/planu/group_meeting/service/GroupScheduleService.java
+++ b/src/main/java/com/planu/group_meeting/service/GroupScheduleService.java
@@ -45,7 +45,20 @@ public class GroupScheduleService {
     @Transactional
     public List<todayScheduleResponse> findTodaySchedulesByToday(Long groupId, LocalDateTime today) {
         checkValidGroupId(groupId);
-        return groupScheduleDAO.findTodaySchedulesByToday(groupId, today);
+        List<todayScheduleResponse> todaySchedules = groupScheduleDAO.findTodaySchedulesByToday(groupId, today);
+
+        for(var schedule : todaySchedules) {
+            String startDate = schedule.getStartDateTime();
+            if(startDate.contains("AM")) {
+                startDate = startDate.replace("AM", "오전");
+            }
+            else if(startDate.contains("PM")) {
+                startDate = startDate.replace("PM", "오후");
+            }
+            schedule.setStartDateTime(startDate);
+        }
+
+        return todaySchedules;
     }
 
     @Transactional


### PR DESCRIPTION
AM, PM으로 주던 정보 오전, 오후로 가공

## #️⃣155

> ex) #155 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 오늘 일정의 시작 날짜 정보를 AM, PM에서 오전, 오후로 가공하여 전달하게 수정하였음.