### PR TITLE
refactor: 유저 식별자 프론트에게 전송할때 username으로 변경

### DIFF
--- a/src/main/java/com/planu/group_meeting/chat/controller/MessageController.java
+++ b/src/main/java/com/planu/group_meeting/chat/controller/MessageController.java
@@ -1,22 +1,22 @@
-package com.planu.group_meeting.chat.controller;
-
-
-import com.planu.group_meeting.chat.dto.ChatMessageRequest;
-import com.planu.group_meeting.config.auth.CustomUserDetails;
-import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
-
-@Controller
-@RequiredArgsConstructor
-public class MessageController {
-
-    private final SimpMessageSendingOperations simpMessageSendingOperations;
-
-    @MessageMapping("/chats")
-    public void mesasge(ChatMessageRequest message, @AuthenticationPrincipal CustomUserDetails userDetails){
-
-    }
-}
+//package com.planu.group_meeting.chat.controller;
+//
+//
+//import com.planu.group_meeting.chat.dto.ChatMessageRequest;
+//import com.planu.group_meeting.config.auth.CustomUserDetails;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.messaging.handler.annotation.MessageMapping;
+//import org.springframework.messaging.simp.SimpMessageSendingOperations;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+//import org.springframework.stereotype.Controller;
+//
+//@Controller
+//@RequiredArgsConstructor
+//public class MessageController {
+//
+//    private final SimpMessageSendingOperations simpMessageSendingOperations;
+//
+//    @MessageMapping("/chats")
+//    public void mesasge(ChatMessageRequest message, @AuthenticationPrincipal CustomUserDetails userDetails){
+//
+//    }
+//}

--- a/src/main/java/com/planu/group_meeting/dto/FriendDto.java
+++ b/src/main/java/com/planu/group_meeting/dto/FriendDto.java
@@ -1,5 +1,6 @@
 package com.planu.group_meeting.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -19,6 +20,7 @@ public class FriendDto {
     @Getter
     @Setter
     public static class FriendInfo{
+        @JsonIgnore
         private Long userId;
         private String name;
         private String username;

--- a/src/main/java/com/planu/group_meeting/dto/ParticipantDto.java
+++ b/src/main/java/com/planu/group_meeting/dto/ParticipantDto.java
@@ -6,9 +6,11 @@ import lombok.Getter;
 public class ParticipantDto {
     @Getter
     public static class ScheduleParticipantResponse{
-        private Long id;
         private String name;
+        private String username;
+        private String profileImage;
     }
+
     @Getter
     public static class UnregisteredParticipantResponse{
         private String name;

--- a/src/main/java/com/planu/group_meeting/dto/ScheduleDto.java
+++ b/src/main/java/com/planu/group_meeting/dto/ScheduleDto.java
@@ -1,8 +1,8 @@
 package com.planu.group_meeting.dto;
 
 import com.planu.group_meeting.entity.Schedule;
-import com.planu.group_meeting.entity.ScheduleParticipant;
-import com.planu.group_meeting.entity.UnregisteredParticipant;
+import com.planu.group_meeting.dto.ParticipantDto.ScheduleParticipantResponse;
+import com.planu.group_meeting.dto.ParticipantDto.UnregisteredParticipantResponse;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -46,7 +46,7 @@ public class ScheduleDto {
         @Size(max = 100, message = "메모는 100자 이내로 입력해주세요.")
         private String memo;
 
-        private List<Long> participants;
+        private List<String> participants;
 
         private List<String> unregisteredParticipants;
 
@@ -76,9 +76,8 @@ public class ScheduleDto {
         private String latitude;
         private String longitude;
         private String memo;
-        private List<ScheduleParticipant> participants = new ArrayList<>();
-        private List<UnregisteredParticipant> unregisteredParticipants = new ArrayList<>();
-
+        private final List<ScheduleParticipantResponse> participants = new ArrayList<>();
+        private final List<UnregisteredParticipantResponse> unregisteredParticipants = new ArrayList<>();
     }
 
     @Getter
@@ -96,8 +95,6 @@ public class ScheduleDto {
         private Long groupId;
         private String title;
         private String location;
-        private String latitude;
-        private String longitude;
         private String startTime;
         private String endTime;
         private String color;

--- a/src/main/java/com/planu/group_meeting/entity/ScheduleParticipant.java
+++ b/src/main/java/com/planu/group_meeting/entity/ScheduleParticipant.java
@@ -14,4 +14,5 @@ public class ScheduleParticipant {
         this.scheduleId = scheduleId;
         this.userId = userId;
     }
+
 }

--- a/src/main/java/com/planu/group_meeting/service/ScheduleService.java
+++ b/src/main/java/com/planu/group_meeting/service/ScheduleService.java
@@ -6,6 +6,7 @@ import com.planu.group_meeting.dto.ScheduleDto.*;
 import com.planu.group_meeting.entity.Schedule;
 import com.planu.group_meeting.entity.ScheduleParticipant;
 import com.planu.group_meeting.entity.UnregisteredParticipant;
+import com.planu.group_meeting.entity.User;
 import com.planu.group_meeting.entity.common.FriendStatus;
 import com.planu.group_meeting.exception.schedule.ScheduleNotFoundException;
 import com.planu.group_meeting.exception.user.NotFoundUserException;
@@ -22,6 +23,7 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,21 +39,30 @@ public class ScheduleService {
     @Transactional
     public void createSchedule(Long userId, ScheduleSaveRequest scheduleDto) {
         Schedule schedule = scheduleDto.toEntity(userId);
-        List<Long> participants = scheduleDto.getParticipants();
-        validateParticipants(userId, participants);
+        List<Long> participantIds = getParticipantIds(scheduleDto.getParticipants());
+        validateParticipants(userId, participantIds);
 
         scheduleDAO.insertSchedule(schedule);
 
-        insertParticipants(schedule, participants);
+        insertParticipants(schedule, participantIds);
         insertUnregisteredParticipants(schedule, scheduleDto.getUnregisteredParticipants());
     }
 
+    private List<Long> getParticipantIds(List<String> participants) {
+        return participants.stream()
+                .map(username -> {
+                    User user = userDAO.findByUsername(username);
+                    if (user == null) {
+                        throw new NotFoundUserException();
+                    }
+                    return user.getId();
+                })
+                .toList();
+    }
+
     private void validateParticipants(Long userId, List<Long> participants) {
-        for(Long participantId : participants){
-            if(!userDAO.existsById(participantId)){
-                throw new NotFoundUserException();
-            }
-            if(friendDAO.getFriendStatus(userId, participantId)!=FriendStatus.FRIEND){
+        for (Long participantId : participants) {
+            if (friendDAO.getFriendStatus(userId, participantId) != FriendStatus.FRIEND) {
                 throw new NotFriendException();
             }
         }
@@ -72,8 +83,7 @@ public class ScheduleService {
 
         participantDAO.deleteAllParticipantsByScheduleId(scheduleId);
         unregisteredParticipantDAO.deleteAllParticipantsByScheduleId(scheduleId);
-
-        insertParticipants(schedule, scheduleSaveRequest.getParticipants());
+        insertParticipants(schedule, getParticipantIds(scheduleSaveRequest.getParticipants()));
         insertUnregisteredParticipants(schedule, scheduleSaveRequest.getUnregisteredParticipants());
     }
 
@@ -111,7 +121,7 @@ public class ScheduleService {
     }
 
     public List<ScheduleCheckResponse> getSchedulesForMonth(Long currentUserId, Long userId, YearMonth yearMonth) {
-        if(!Objects.equals(userId, currentUserId) && friendDAO.getFriendStatus(currentUserId,userId) != FriendStatus.FRIEND){
+        if (!Objects.equals(userId, currentUserId) && friendDAO.getFriendStatus(currentUserId, userId) != FriendStatus.FRIEND) {
             throw new NotFoundUserException();
         }
 
@@ -155,11 +165,12 @@ public class ScheduleService {
 
     private void insertParticipants(Schedule schedule, List<Long> participantIds) {
         if (participantIds != null && !participantIds.isEmpty()) {
-            List<ScheduleParticipant> participants = participantIds.stream()
-                    .map(userId -> new ScheduleParticipant(schedule.getId(), userId))
+            List<ScheduleParticipant> scheduleParticipants = participantIds.stream()
+                    .map(participant -> new ScheduleParticipant(schedule.getId(), participant))
                     .toList();
-            participantDAO.insertScheduleParticipants(participants);
+            participantDAO.insertScheduleParticipants(scheduleParticipants);
         }
+
     }
 
     private void insertUnregisteredParticipants(Schedule schedule, List<String> unregisteredParticipantNames) {

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -11,11 +11,14 @@
         <result property="endDateTime" column="endDateTime"/>
         <result property="color" column="color"/>
         <result property="location" column="location"/>
+        <result property="latitude" column="latitude"/>
+        <result property="longitude" column="longitude"/>
         <result property="memo" column="memo"/>
         <collection property="participants"
                     ofType="com.planu.group_meeting.dto.ParticipantDto$ScheduleParticipantResponse">
-            <result property="id" column="participantId"/>
             <result property="name" column="participantName"/>
+            <result property="username" column="participantUsername"/>
+            <result property="profileImage" column="participantProfileImage"/>
         </collection>
         <collection property="unregisteredParticipants"
                     ofType="com.planu.group_meeting.dto.ParticipantDto$UnregisteredParticipantResponse">
@@ -92,8 +95,10 @@
         s.LATITUDE AS latitude,
         s.LONGITUDE AS longitude,
         s.MEMO AS memo,
-        u.ID AS participantId,
+
         u.NAME AS participantName,
+        u.USERNAME AS participantUsername,
+        u.PROFILE_IMG_URL AS participantProfileImage,
         up.PARTICIPANT_NAME AS unregisteredParticipantName
         FROM SCHEDULE s
         LEFT JOIN SCHEDULE_PARTICIPANT sp ON s.ID = sp.SCHEDULE_ID
@@ -109,8 +114,6 @@
         NULL AS groupId,
         S.TITLE,
         S.LOCATION,
-        S.LATITUDE,
-        S.LONGITUDE,
         DATE_FORMAT(S.START_DATETIME, '%H:%i') AS startTime,
         DATE_FORMAT(S.END_DATETIME, '%H:%i') AS endTime,
         S.COLOR
@@ -126,8 +129,6 @@
         GS.GROUP_ID AS groupId,
         GS.TITLE,
         GS.LOCATION,
-        GS.LATITUDE,
-        GS.LONGITUDE,
         DATE_FORMAT(GS.START_DATETIME, '%H:%i') AS startTime,
         DATE_FORMAT(GS.END_DATETIME, '%H:%i') AS endTime,
         GS.COLOR


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #200

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> - 유저 식별자에 대한 데이터를 userId에서 username으로 요청응답 포맷 전면 수정

## 📝수정 내용(선택)
> -

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
