### PR TITLE
fix: 위도, 경도 타입 double형으로 수정

### DIFF
--- a/src/main/java/com/planu/group_meeting/dto/ScheduleDto.java
+++ b/src/main/java/com/planu/group_meeting/dto/ScheduleDto.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -39,9 +38,9 @@ public class ScheduleDto {
 
         private String location;
 
-        private BigDecimal latitude;
+        private double latitude;
 
-        private BigDecimal longitude;
+        private double longitude;
 
         @Size(max = 100, message = "메모는 100자 이내로 입력해주세요.")
         private String memo;
@@ -73,8 +72,8 @@ public class ScheduleDto {
         private LocalDateTime startDateTime;
         private LocalDateTime endDateTime;
         private String location;
-        private String latitude;
-        private String longitude;
+        private double latitude;
+        private double longitude;
         private String memo;
         private final List<ScheduleParticipantResponse> participants = new ArrayList<>();
         private final List<UnregisteredParticipantResponse> unregisteredParticipants = new ArrayList<>();

--- a/src/main/java/com/planu/group_meeting/entity/Schedule.java
+++ b/src/main/java/com/planu/group_meeting/entity/Schedule.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Data
@@ -21,8 +20,8 @@ public class Schedule {
     ScheduleVisibility visibility;
     private String memo;
     private String location;
-    private BigDecimal latitude;
-    private BigDecimal longitude;
+    private double latitude;
+    private double longitude;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #225 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> -  latitude, longitude 필드 자료형 double 로 변경

## 📝수정 내용(선택)
> -

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
