### PR TITLE
feat: 그룹 일정 정보 API 수정

### DIFF
--- a/src/main/java/com/planu/group_meeting/controller/GroupScheduleController.java
+++ b/src/main/java/com/planu/group_meeting/controller/GroupScheduleController.java
@@ -109,5 +109,17 @@ public class GroupScheduleController implements GroupScheduleDocs {
         response.put("groupScheduleData", groupScheduleService.getGroupCalendarEvents(groupId, yearMonth, groupUserService));
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/{groupId}/calendar")
+    public ResponseEntity<Map<String, Object>> getGroupScheduleByYearMonth(
+            @PathVariable("groupId") Long groupId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") @Nullable YearMonth yearMonth,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        groupUserService.isGroupMember(userDetails.getId(), groupId);
+        Map<String, Object> response = new HashMap<>();
+        response.put("groupSchedules", groupScheduleService.getGroupScheduleByYearMonth(groupId, yearMonth));
+        return ResponseEntity.ok(response);
+    }
 }
 

--- a/src/main/java/com/planu/group_meeting/controller/docs/GroupScheduleDocs.java
+++ b/src/main/java/com/planu/group_meeting/controller/docs/GroupScheduleDocs.java
@@ -619,4 +619,83 @@ public interface GroupScheduleDocs {
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM") @Nullable YearMonth yearMonth,
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
+
+    @Operation(summary = "달력의 그룹 정보", description = "그룹 달력에 그룹 일정 정보를 제공")
+    @ApiResponses
+            ({
+                    @ApiResponse
+                            (
+                                    responseCode = "200",
+                                    description = "그룹 달력 일정 조회 성공",
+                                    content = @Content
+                                            (
+                                                    mediaType = "application/json",
+                                                    schema = @Schema
+                                                            (
+                                                                    example = """
+                                                                            {
+                                                                                "groupSchedules": [
+                                                                                    {
+                                                                                        "id": 5,
+                                                                                        "title": "술약",
+                                                                                        "startDateTime": "2024-02-20",
+                                                                                        "endDateTime": "2024-02-20",
+                                                                                        "color": "#44AA44"
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 8,
+                                                                                        "title": "1박 2일 여행",
+                                                                                        "startDateTime": "2024-02-02",
+                                                                                        "endDateTime": "2024-02-03",
+                                                                                        "color": "#55FFFF"
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 3,
+                                                                                        "title": "수현이 생일파티",
+                                                                                        "startDateTime": "2024-02-19",
+                                                                                        "endDateTime": "2024-02-19",
+                                                                                        "color": "#22FFFF"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                            """
+                                                            )
+
+                                            )
+                            ),
+                    @ApiResponse
+                            (
+                                    responseCode = "404",
+                                    description = "그룹을 찾을 수 없습니다.",
+                                    content = @Content
+                                            (
+                                                    mediaType = "application/json",
+                                                    schema = @Schema
+                                                            (
+                                                                    example = "{\"resultCode\": 404, \"resultMsg\": \"그룹을 찾을 수 없습니다.\"}"
+                                                            )
+                                            )
+
+                            ),
+                    @ApiResponse
+                            (
+                                    responseCode = "403",
+                                    description = "그룹원이 아닌 경우",
+                                    content = @Content
+                                            (
+                                                    mediaType = "application/json",
+                                                    schema = @Schema
+                                                            (
+                                                                    example = "{\"resultCode\": 403, \"resultMsg\": \"접근 권한이 없습니다.\"}"
+                                                            )
+                                            )
+                            )
+
+            })
+    public ResponseEntity<Map<String, Object>> getGroupScheduleByYearMonth
+            (
+                    @PathVariable("groupId") Long groupId,
+                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM") @Nullable YearMonth yearMonth,
+                    @AuthenticationPrincipal CustomUserDetails userDetails
+            );
 }

--- a/src/main/java/com/planu/group_meeting/dao/GroupScheduleDAO.java
+++ b/src/main/java/com/planu/group_meeting/dao/GroupScheduleDAO.java
@@ -31,4 +31,6 @@ public interface GroupScheduleDAO {
     void updateGroupSchedule(GroupSchedule groupSchedule);
 
     Boolean existsGroupScheduleByDate(Long groupId, LocalDate date);
+
+    List<scheduleOverViewResponse> getGroupScheduleByYearMonth(Long groupId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/planu/group_meeting/service/GroupScheduleService.java
+++ b/src/main/java/com/planu/group_meeting/service/GroupScheduleService.java
@@ -193,4 +193,18 @@ public class GroupScheduleService {
         }
         return groupCalendarEvents;
     }
+
+    public List<scheduleOverViewResponse> getGroupScheduleByYearMonth(Long groupId, YearMonth yearMonth) {
+        checkValidGroupId(groupId);
+        if(yearMonth == null) {
+            yearMonth = YearMonth.now();
+        }
+        LocalDate firstDayOfMonth = yearMonth.atDay(1);
+        LocalDate lastDayOfMonth = yearMonth.atEndOfMonth();
+
+        LocalDate startOfCalendar = firstDayOfMonth.minusDays(firstDayOfMonth.getDayOfWeek().getValue() % 7);
+        LocalDate endOfCalendar = lastDayOfMonth.plusDays(6 - lastDayOfMonth.getDayOfWeek().getValue());
+
+        return groupScheduleDAO.getGroupScheduleByYearMonth(groupId, startOfCalendar, endOfCalendar);
+    }
 }

--- a/src/main/resources/mapper/GroupScheduleMapper.xml
+++ b/src/main/resources/mapper/GroupScheduleMapper.xml
@@ -98,4 +98,12 @@
         WHERE
             group_id = #{groupId} and id = #{id}
     </update>
+
+    <select id="getGroupScheduleByYearMonth" resultType="com.planu.group_meeting.dto.GroupScheduleDTO$scheduleOverViewResponse">
+        SELECT id, title, start_datetime as startTime, end_datetime as endTime, color
+        FROM GROUP_SCHEDULE
+        WHERE group_id = #{groupId} and start_datetime >= #{startDate} and #{endDate} >= end_datetime
+        ORDER BY date(start_datetime) ASC, datediff(end_datetime, start_datetime) desc;
+    </select>
+
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #278 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> - 그룹 달력 일정 정보 조회를 다시 생성합니다.

