### PR TITLE
fix: 그룹 일정 유무 조회 API 수정

### DIFF
--- a/src/main/resources/mapper/GroupScheduleMapper.xml
+++ b/src/main/resources/mapper/GroupScheduleMapper.xml
@@ -21,7 +21,10 @@
             DATE_FORMAT(end_datetime, '%Y-%m-%d %H:%i') as endTime,
             color
         FROM GROUP_SCHEDULE
-        WHERE group_id = #{groupId} and start_datetime >= #{startDate} and end_datetime >= #{startDate}
+        WHERE group_id = #{groupId}
+        AND (
+        DATE(start_datetime) = #{startDate}
+        OR ( #{startDate} >= start_datetime AND end_datetime >= #{startDate}) )
         ORDER BY date(start_datetime) ASC, datediff(end_datetime, start_datetime) desc;
     </select>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #295

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> - 우선적으로 이전 날짜 정보 요청시 해당 날짜에 해당하는 일정 정보만
반환하도록 수정


